### PR TITLE
post_type 스크래핑 오류 수정(모두 기본 처리)

### DIFF
--- a/app/board/infra/scraper/boards/additional_board_scraper.py
+++ b/app/board/infra/scraper/boards/additional_board_scraper.py
@@ -68,8 +68,7 @@ class AdditionalBoardScraper(BoardScraper):
                     date = re.sub(r"작성일", "", date).strip()
 
                     # 카테고리 (일반, 학사 등)
-                    category_tag = li.select_one(".cate")
-                    post_type = category_tag.text.strip("[]") if category_tag else "N/A"
+                    post_type = "기본"
 
                     # 조회수
                     views_tag = li.select_one(".board-thumb-content-views")

--- a/app/board/infra/scraper/boards/library_board_scraper.py
+++ b/app/board/infra/scraper/boards/library_board_scraper.py
@@ -63,8 +63,7 @@ class LibraryBoardScraper(BoardScraper):
                     date = date.replace(".", "-") #yyyy.mm.dd 를 yyyy-mm-dd로 변경 
 
                     # 카테고리 버튼 (일반, 학사 등)
-                    btn = dl.select_one("dd a > span.btn") or dl.select_one("dd > span.btn") #span btn 탐색 후 선택
-                    post_type = btn.get_text(strip=True) if btn else "N/A"
+                    post_type = "기본"
 
                     if post_type and title.startswith(post_type):
                         title = title[len(post_type):].strip()  #카테고리식으로 들어간 앞 단어(ex. [학술]) 제거

--- a/app/board/infra/scraper/boards/major_board_scraper.py
+++ b/app/board/infra/scraper/boards/major_board_scraper.py
@@ -69,8 +69,7 @@ class MajorBoardScraper(BoardScraper):
                     )
 
                     # 카테고리
-                    category_tag = li.select_one(".cate")
-                    post_type = category_tag.get_text(strip=True).strip("[]") if category_tag else "N/A"    #학과 게시판들은 카테고리 N/A
+                    post_type = "기본"
 
                     # 첨부파일 여부
                     file_tag = li.select_one("div.file_downWrap ul.filedown_list li")

--- a/app/board/infra/scraper/boards/smcareer_board_scraper.py
+++ b/app/board/infra/scraper/boards/smcareer_board_scraper.py
@@ -106,7 +106,7 @@ class SmCareerBoardScraper(BoardScraper):
                         date = raw_date
 
                     # 카테고리: 기본값으로
-                    post_type = "N/A"
+                    post_type = "기본"
 
                     # 조회수: 다섯 번째 td 안의 <p>
                     view_p     = tr.select("td")[4].select_one("p")

--- a/app/board/infra/scraper/boards/swai_board_scraper.py
+++ b/app/board/infra/scraper/boards/swai_board_scraper.py
@@ -66,8 +66,7 @@ class SwaiBoardScraper(BoardScraper):
                     date = date_tag.get_text(strip=True) if date_tag else "N/A"
 
                     # 카테고리
-                    category_tag = tr.select_one(".cate")
-                    post_type = category_tag.get_text(strip=True).strip("[]") if category_tag else "N/A"
+                    post_type = "기본"
 
                     # 조회수
                     views_tag = tr.select_one("td.td_num")


### PR DESCRIPTION
post_type으로 다른 태그가 스크래핑 되는 오류를 수정
게시물 링크로 타고 들어간 상황에서 DB 제목 상 앞에 [생활] [논문] 과 같이 붙는 경우, 해당 게시물 내에서는 직접적으로 제목에 포함되어 있지 않으나 게시판에서 확인 시 앞에 [ ~ ] 가 붙어있어 포함되어 붙은 채로 스크래핑 됩니다.